### PR TITLE
feat: add PUT /grants/{grant_id} endpoint for editing grants

### DIFF
--- a/bento_authorization_service/db.py
+++ b/bento_authorization_service/db.py
@@ -233,6 +233,19 @@ class Database(PgAsyncDatabase):
                 await conn.execute('DELETE FROM grant_permissions WHERE "grant" = $1', grant_id)
                 await self.add_grant_permissions(grant_id, permissions, existing_conn=conn)
 
+    async def update_grant(self, grant_id: int, grant: GrantModel) -> None:
+        conn: asyncpg.Connection
+        async with self.connect() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    'UPDATE grants SET "expiry" = $2, "notes" = $3 WHERE "id" = $1',
+                    grant_id,
+                    grant.expiry,
+                    grant.notes,
+                )
+                await conn.execute('DELETE FROM grant_permissions WHERE "grant" = $1', grant_id)
+                await self.add_grant_permissions(grant_id, grant.permissions, existing_conn=conn)
+
     async def delete_grant(self, grant_id: int) -> None:
         conn: asyncpg.Connection
         async with self.connect() as conn:

--- a/bento_authorization_service/routers/grants.py
+++ b/bento_authorization_service/routers/grants.py
@@ -8,7 +8,7 @@ from ..db import Database, DatabaseDependency
 from ..dependencies import OptionalBearerToken
 from ..logger import LoggerDependency
 from ..idp_manager import BaseIdPManager, IdPManagerDependency
-from ..models import GrantModel, StoredGrantModel
+from ..models import GrantModel, ResourceModel, StoredGrantModel
 from ..policy_engine.evaluation import evaluate
 from ..utils import extract_token
 
@@ -25,6 +25,23 @@ def grant_not_found(grant_id: int) -> HTTPException:
 
 def grant_could_not_be_created() -> HTTPException:
     return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Grant could not be created")
+
+
+def _validate_grant_fields(expiry: datetime | None, perms: frozenset[str], resource: ResourceModel) -> None:
+    if expiry is not None and expiry < datetime.now(timezone.utc):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Grant expiry is already in the past")
+
+    resource_dict = resource.model_dump(exclude_none=True)
+    for p in perms:
+        if p not in PERMISSIONS_BY_STRING:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=f"Grant specifies invalid permission {p}"
+            )
+        if not permission_valid_for_resource(PERMISSIONS_BY_STRING[p], resource_dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Grant specifies incompatible permission {p} for resource {resource_dict}",
+            )
 
 
 async def get_grant_and_check_access(
@@ -83,22 +100,7 @@ async def create_grant(
     # Flag that we have thought about auth
     authz_middleware.mark_authz_done(request)
 
-    # Forbid creating a grant which is expired from the get-go.
-    if grant.expiry is not None and grant.expiry < datetime.now(timezone.utc):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Grant is already expired")
-
-    for p in grant.permissions:
-        if p not in PERMISSIONS_BY_STRING:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail=f"Grant specifies invalid permission {p}"
-            )
-
-        resource_dict = grant.resource.model_dump(exclude_none=True)
-        if not permission_valid_for_resource(PERMISSIONS_BY_STRING[p], resource_dict):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Grant specifies incompatible permission {p} for resource {resource_dict}",
-            )
+    _validate_grant_fields(grant.expiry, grant.permissions, grant.resource)
 
     # Create the grant
     if (g_id := await db.create_grant(grant)) is not None:
@@ -145,22 +147,7 @@ async def update_grant(
     # Flag that we have thought about auth
     authz_middleware.mark_authz_done(request)
 
-    # Forbid updating a grant to an already-expired expiry.
-    if grant.expiry is not None and grant.expiry < datetime.now(timezone.utc):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Grant expiry is already in the past")
-
-    for p in grant.permissions:
-        if p not in PERMISSIONS_BY_STRING:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail=f"Grant specifies invalid permission {p}"
-            )
-
-        resource_dict = existing_grant.resource.model_dump(exclude_none=True)
-        if not permission_valid_for_resource(PERMISSIONS_BY_STRING[p], resource_dict):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Grant specifies incompatible permission {p} for resource {resource_dict}",
-            )
+    _validate_grant_fields(grant.expiry, grant.permissions, existing_grant.resource)
 
     await db.update_grant(grant_id, grant)
 

--- a/bento_authorization_service/routers/grants.py
+++ b/bento_authorization_service/routers/grants.py
@@ -128,6 +128,43 @@ async def get_grant(
     return grant
 
 
+@grants_router.put("/{grant_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def update_grant(
+    request: Request,
+    grant_id: int,
+    grant: GrantModel,
+    db: DatabaseDependency,
+    idp_manager: IdPManagerDependency,
+    authorization: OptionalBearerToken,
+):
+    # Make sure the grant exists, and we have permissions-editing capabilities on the existing resource.
+    existing_grant = await get_grant_and_check_access(
+        request, extract_token(authorization), grant_id, P_EDIT_PERMISSIONS, db, idp_manager
+    )
+
+    # Flag that we have thought about auth
+    authz_middleware.mark_authz_done(request)
+
+    # Forbid updating a grant to an already-expired expiry.
+    if grant.expiry is not None and grant.expiry < datetime.now(timezone.utc):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Grant expiry is already in the past")
+
+    for p in grant.permissions:
+        if p not in PERMISSIONS_BY_STRING:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=f"Grant specifies invalid permission {p}"
+            )
+
+        resource_dict = existing_grant.resource.model_dump(exclude_none=True)
+        if not permission_valid_for_resource(PERMISSIONS_BY_STRING[p], resource_dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Grant specifies incompatible permission {p} for resource {resource_dict}",
+            )
+
+    await db.update_grant(grant_id, grant)
+
+
 @grants_router.delete("/{grant_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_grant(
     request: Request,
@@ -148,4 +185,3 @@ async def delete_grant(
     await db.delete_grant(grant_id)
 
 
-# EXPLICITLY: No grant updating; they are immutable.

--- a/bento_authorization_service/routers/grants.py
+++ b/bento_authorization_service/routers/grants.py
@@ -183,5 +183,3 @@ async def delete_grant(
 
     # If the above didn't raise anything, delete the grant.
     await db.delete_grant(grant_id)
-
-

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 from bento_lib.auth import permissions
+from datetime import datetime, timedelta, timezone
 from fastapi import status
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
@@ -202,6 +203,119 @@ async def test_grant_endpoints_list(test_client: TestClient, db: Database, db_cl
     res = test_client.get("/grants/", headers=headers)
     assert res.status_code == status.HTTP_200_OK
     assert any(True for g in res.json() if json.dumps(g, sort_keys=True) == db_grant_json)
+
+
+# noinspection PyUnusedLocal
+@pytest.mark.asyncio
+async def test_grant_db_update(db: Database, db_cleanup):
+    g_id = await db.create_grant(sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA)
+    assert (await db.get_grant(g_id)).permissions == frozenset({permissions.P_QUERY_DATA})
+
+    updated = GrantModel(
+        subject=sd.SUBJECT_DAVID,
+        resource=sd.RESOURCE_PROJECT_1,
+        permissions=frozenset({permissions.P_QUERY_DATA, permissions.P_INGEST_DATA}),
+        notes="updated notes",
+        expiry=None,
+    )
+    await db.update_grant(g_id, updated)
+
+    g = await db.get_grant(g_id)
+    assert g.permissions == frozenset({permissions.P_QUERY_DATA, permissions.P_INGEST_DATA})
+    assert g.notes == "updated notes"
+
+
+# noinspection PyUnusedLocal
+@pytest.mark.asyncio
+async def test_grant_endpoints_update(auth_headers: dict[str, str], test_client: TestClient, db: Database, db_cleanup):
+    g_id = await db.create_grant(sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA)
+
+    updated_grant = {
+        **sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA.model_dump(mode="json"),
+        "permissions": [permissions.P_QUERY_DATA, permissions.P_INGEST_DATA],
+        "notes": "updated",
+    }
+
+    # no token - forbidden
+    res = test_client.put(f"/grants/{g_id}", json=updated_grant)
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    # valid token - success
+    res = test_client.put(f"/grants/{g_id}", json=updated_grant, headers=auth_headers)
+    assert res.status_code == status.HTTP_204_NO_CONTENT
+
+    g: StoredGrantModel = await db.get_grant(g_id)
+    assert g.permissions == frozenset({permissions.P_QUERY_DATA, permissions.P_INGEST_DATA})
+    assert g.notes == "updated"
+
+
+# noinspection PyUnusedLocal
+@pytest.mark.asyncio
+async def test_grant_endpoints_update_not_found(
+    auth_headers: dict[str, str], test_client: TestClient, db: Database, db_cleanup
+):
+    body = {
+        **sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA.model_dump(mode="json"),
+        "permissions": [permissions.P_QUERY_DATA],
+    }
+    res = test_client.put("/grants/0", json=body, headers=auth_headers)
+    assert res.status_code == status.HTTP_404_NOT_FOUND
+
+
+# noinspection PyUnusedLocal
+@pytest.mark.asyncio
+async def test_grant_endpoints_update_expired(
+    auth_headers: dict[str, str], test_client: TestClient, db: Database, db_cleanup
+):
+    g_id = await db.create_grant(sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA)
+
+    past_expiry = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    body = {
+        **sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA.model_dump(mode="json"),
+        "permissions": [permissions.P_QUERY_DATA],
+        "expiry": past_expiry,
+    }
+    res = test_client.put(f"/grants/{g_id}", json=body, headers=auth_headers)
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# noinspection PyUnusedLocal
+@pytest.mark.asyncio
+async def test_grant_endpoints_update_invalid_permission(
+    auth_headers: dict[str, str], test_client: TestClient, db: Database, db_cleanup
+):
+    g_id = await db.create_grant(sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA)
+
+    body = {
+        **sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA.model_dump(mode="json"),
+        "permissions": ["fake:permission"],
+    }
+    res = test_client.put(f"/grants/{g_id}", json=body, headers=auth_headers)
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+    assert "invalid permission fake:permission" in res.json()["errors"][0]["message"]
+
+
+# noinspection PyUnusedLocal
+@pytest.mark.asyncio
+async def test_grant_endpoints_update_invalid_for_resource(
+    auth_headers: dict[str, str], test_client: TestClient, db: Database, db_cleanup
+):
+    grant = GrantModel(
+        subject=sd.SUBJECT_EVERYONE,
+        resource=sd.RESOURCE_PROJECT_1_PHENOPACKET,
+        permissions={permissions.P_QUERY_DATA},
+        notes="",
+        expiry=None,
+    )
+    g_id = await db.create_grant(grant)
+
+    body = {
+        **grant.model_dump(mode="json"),
+        "permissions": [permissions.P_CREATE_DATASET],
+    }
+    res = test_client.put(f"/grants/{g_id}", json=body, headers=auth_headers)
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+    assert "incompatible permission create:dataset for resource" in res.json()["errors"][0]["message"]
 
 
 # noinspection PyUnusedLocal

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -277,6 +277,7 @@ async def test_grant_endpoints_update_expired(
     }
     res = test_client.put(f"/grants/{g_id}", json=body, headers=auth_headers)
     assert res.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Grant expiry is already in the past" in res.json()["errors"][0]["message"]
 
 
 # noinspection PyUnusedLocal

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -251,6 +251,27 @@ async def test_grant_endpoints_update(auth_headers: dict[str, str], test_client:
 
 # noinspection PyUnusedLocal
 @pytest.mark.asyncio
+async def test_grant_endpoints_update_expiry(
+    auth_headers: dict[str, str], test_client: TestClient, db: Database, db_cleanup
+):
+    g_id = await db.create_grant(sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA)
+
+    future_expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+    body = {
+        **sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA.model_dump(mode="json"),
+        "permissions": list(sd.TEST_GRANT_DAVID_PROJECT_1_QUERY_DATA.permissions),
+        "expiry": future_expiry.isoformat(),
+    }
+    res = test_client.put(f"/grants/{g_id}", json=body, headers=auth_headers)
+    assert res.status_code == status.HTTP_204_NO_CONTENT
+
+    g: StoredGrantModel = await db.get_grant(g_id)
+    assert g.expiry is not None
+    assert abs((g.expiry - future_expiry).total_seconds()) < 1
+
+
+# noinspection PyUnusedLocal
+@pytest.mark.asyncio
 async def test_grant_endpoints_update_not_found(
     auth_headers: dict[str, str], test_client: TestClient, db: Database, db_cleanup
 ):


### PR DESCRIPTION
## Summary

- Adds `update_grant` to the DB layer, atomically updating `expiry`, `notes`, and `permissions` in a single transaction
- Adds `PUT /grants/{grant_id}` endpoint with authz (`P_EDIT_PERMISSIONS` on the grant's resource) and the same input validation as the create endpoint
- `subject` and `resource` are not editable (changing those would be a delete + create)